### PR TITLE
flips space bat's damage range and the sergeant no longer spawns hurt 

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
@@ -16,8 +16,8 @@
 	health = 15
 	see_in_dark = 10
 	harm_intent_damage = 6
-	melee_damage_lower = 6
-	melee_damage_upper = 5
+	melee_damage_lower = 5
+	melee_damage_upper = 6
 	attack_verb_continuous = "bites"
 	attack_verb_simple = "bite"
 	butcher_results = list(/obj/item/food/meat/slab = 1)
@@ -48,7 +48,7 @@
 	emote_hear = list("chitters")
 	faction = list("spiders")
 	harm_intent_damage = 3
-	health = 200
+	health = 250
 	icon_dead = "guard_dead"
 	icon_gib = "guard_dead"
 	icon_living = "guard"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

flips the min and max damage so at max they do 6 and at min they do 5 instead of the inverse. also raises Sergeant Araneus health to 250  from 200 (not max health, he already has 250 max they just spawned hurt)

## Why It's Good For The Game

fixing the space bat's damage numbers and patching up Sergeant Araneus's wounds before shipping him out

## Changelog
:cl:
fix: fixed space bat's damage numbers
fix: Sergeant Araneus spawning already hurt
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
